### PR TITLE
feat: configure additional firewall ports

### DIFF
--- a/lib/_system.sh
+++ b/lib/_system.sh
@@ -37,9 +37,10 @@ ufw default deny incoming
 ufw default allow outgoing
 ufw allow ssh
 ufw allow 22
-ufw allow 80
-ufw allow 443
 ufw allow 9000
+ufw allow 4444
+ufw allow 6000
+ufw allow 6100
 ufw --force enable
 echo "{\"iptables\": false}" > /etc/docker/daemon.json
 systemctl restart docker
@@ -158,8 +159,6 @@ system_update() {
   sudo su - root <<EOF
   apt -y update && apt -y upgrade
   apt autoremove -y
-  sudo ufw allow 443/tcp
-  sudo ufw allow 80/tcp
 EOF
 
   sleep 2


### PR DESCRIPTION
## Summary
- open firewall ports 4444, 6000, and 6100
- remove unused 80 and 443 allowances

## Testing
- `bash -n lib/_system.sh`
- `ufw reload` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y ufw` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f3c68082083238d4cfd3b811204ca